### PR TITLE
Update gemspec to use current version, edit namespaces to reflect the change

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -9,7 +9,7 @@ module Spree
   module Calculator::Shipping
     module ActiveShipping
       class Base < ShippingCalculator
-        include ActiveMerchant::Shipping
+        include ActiveShipping
 
         def self.service_name
           self.description
@@ -49,15 +49,15 @@ module Spree
         def timing(line_items)
           order = line_items.first.order
           # TODO: Figure out where stock_location is supposed to come from.
-          origin= Location.new(:country => stock_location.country.iso,
-                               :city => stock_location.city,
-                               :state => (stock_location.state ? stock_location.state.abbr : stock_location.state_name),
-                               :zip => stock_location.zipcode)
+          origin = ::ActiveShipping::Location.new(country: stock_location.country.iso,
+                               city: stock_location.city,
+                               state: (stock_location.state ? stock_location.state.abbr : stock_location.state_name),
+                               zip: stock_location.zipcode)
           addr = order.ship_address
-          destination = Location.new(:country => addr.country.iso,
-                                     :state => (addr.state ? addr.state.abbr : addr.state_name),
-                                     :city => addr.city,
-                                     :zip => addr.zipcode)
+          destination = ::ActiveShipping::Location.new(country: addr.country.iso,
+                                     state: (addr.state ? addr.state.abbr : addr.state_name),
+                                     city: addr.city,
+                                     zip: addr.zipcode)
           timings_result = Rails.cache.fetch(cache_key(package)+"-timings") do
             retrieve_timings(origin, destination, packages(order))
           end
@@ -104,9 +104,9 @@ module Spree
             end
             rate_hash = Hash[*rates.flatten]
             return rate_hash
-          rescue ActiveMerchant::ActiveMerchantError => e
+          rescue ::ActiveShipping::Error => e
 
-            if [ActiveMerchant::ResponseError, ActiveMerchant::Shipping::ResponseError].include?(e.class) && e.response.is_a?(ActiveMerchant::Shipping::Response)
+            if [::ActiveShipping::ResponseError].include?(e.class) && e.response.is_a?(::ActiveShipping::Response)
               params = e.response.params
               if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")
                 message = params["Response"]["Error"]["ErrorDescription"]
@@ -134,8 +134,8 @@ module Spree
               response = carrier.find_time_in_transit(origin, destination, packages)
               return response
             end
-          rescue ActiveMerchant::Shipping::ResponseError => re
-            if re.response.is_a?(ActiveMerchant::Shipping::Response)
+          rescue ::ActiveShipping::ResponseError => re
+            if re.response.is_a?(::ActiveShipping::Response)
               params = re.response.params
               if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")
                 message = params["Response"]["Error"]["ErrorDescription"]
@@ -278,10 +278,10 @@ module Spree
         end
 
         def build_location address
-          Location.new(:country => address.country.iso,
-                       :state   => fetch_best_state_from_address(address),
-                       :city    => address.city,
-                       :zip     => address.zipcode)
+          ::ActiveShipping::Location.new(country: address.country.iso,
+                       state: fetch_best_state_from_address(address),
+                       city: address.city,
+                       zip: address.zipcode)
         end
 
         def retrieve_rates_from_cache package, origin, destination

--- a/app/models/spree/calculator/shipping/canada_post/base.rb
+++ b/app/models/spree/calculator/shipping/canada_post/base.rb
@@ -9,7 +9,7 @@ module Spree
             :login  => Spree::ActiveShipping::Config[:canada_post_login],
             :french => (I18n.locale.to_sym == :fr)
           }
-          ActiveMerchant::Shipping::CanadaPost.new(canada_post_options)
+          ::ActiveShipping::CanadaPost.new(canada_post_options)
         end
       end
     end

--- a/app/models/spree/calculator/shipping/fedex/base.rb
+++ b/app/models/spree/calculator/shipping/fedex/base.rb
@@ -13,7 +13,7 @@ module Spree
             :test => Spree::ActiveShipping::Config[:test_mode]
           }
 
-          ActiveMerchant::Shipping::FedEx.new(carrier_details)
+          ::ActiveShipping::FedEx.new(carrier_details)
         end
       end
     end

--- a/app/models/spree/calculator/shipping/ups/base.rb
+++ b/app/models/spree/calculator/shipping/ups/base.rb
@@ -16,7 +16,7 @@ module Spree
             carrier_details.merge!(:origin_account => shipper_number)
           end
 
-          ActiveMerchant::Shipping::UPS.new(carrier_details)
+          ::ActiveShipping::UPS.new(carrier_details)
         end
 
         protected

--- a/app/models/spree/calculator/shipping/usps/base.rb
+++ b/app/models/spree/calculator/shipping/usps/base.rb
@@ -34,7 +34,7 @@ module Spree
             :test => Spree::ActiveShipping::Config[:test_mode]
           }
 
-          ActiveMerchant::Shipping::USPS.new(carrier_details)
+          ::ActiveShipping::USPS.new(carrier_details)
         end
 
         private
@@ -50,9 +50,9 @@ module Spree
             end
             rate_hash = Hash[*rates.flatten]
             return rate_hash
-          rescue ActiveMerchant::ActiveMerchantError => e
+          rescue ::ActiveShipping::Error => e
 
-            if [ActiveMerchant::ResponseError, ActiveMerchant::Shipping::ResponseError].include?(e.class) && e.response.is_a?(ActiveMerchant::Shipping::Response)
+            if [::ActiveShipping::ResponseError].include?(e.class) && e.response.is_a?(::ActiveShipping::Response)
               params = e.response.params
               if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")
                 message = params["Response"]["Error"]["ErrorDescription"]

--- a/lib/solidus_active_shipping/engine.rb
+++ b/lib/solidus_active_shipping/engine.rb
@@ -18,10 +18,10 @@ module SolidusActiveShipping
 
       #Only required until following active_shipping commit is merged (add negotiated rates).
       #http://github.com/BDQ/active_shipping/commit/2f2560d53aa7264383e5a35deb7264db60eb405a
-      ActiveMerchant::Shipping::UPS.send(:include, Spree::ActiveShipping::UpsOverride)
+      ::ActiveShipping::UPS.send(:include, Spree::ActiveShipping::UpsOverride)
 
       # Fix Canada Post "Ready to ship" package
-      ActiveMerchant::Shipping::CanadaPost.send(:include, Spree::ActiveShipping::CanadaPostOverride)
+      ::ActiveShipping::CanadaPost.send(:include, Spree::ActiveShipping::CanadaPostOverride)
     end
 
     config.autoload_paths += %W(#{config.root}/lib)

--- a/lib/spree/active_shipping/ups_override.rb
+++ b/lib/spree/active_shipping/ups_override.rb
@@ -18,12 +18,12 @@ module Spree
                pickup_type = options[:pickup_type] || :daily_pickup
 
                root_node << XmlNode.new('PickupType') do |pickup_type_node|
-                 pickup_type_node << XmlNode.new('Code', ActiveMerchant::Shipping::UPS::PICKUP_CODES[pickup_type])
+                 pickup_type_node << XmlNode.new('Code', ::ActiveShipping::UPS::PICKUP_CODES[pickup_type])
                  # not implemented: PickupType/PickupDetails element
                end
-               cc = options[:customer_classification] || ActiveMerchant::Shipping::UPS::DEFAULT_CUSTOMER_CLASSIFICATIONS[pickup_type]
+               cc = options[:customer_classification] || ::ActiveShipping::UPS::DEFAULT_CUSTOMER_CLASSIFICATIONS[pickup_type]
                root_node << XmlNode.new('CustomerClassification') do |cc_node|
-                 cc_node << XmlNode.new('Code', ActiveMerchant::Shipping::UPS::CUSTOMER_CLASSIFICATIONS[cc])
+                 cc_node << XmlNode.new('Code', ::ActiveShipping::UPS::CUSTOMER_CLASSIFICATIONS[cc])
                end
 
                root_node << XmlNode.new('Shipment') do |shipment|
@@ -253,8 +253,8 @@ module Spree
                 negotiated_rate = rated_shipment.get_text('NegotiatedRates/NetSummaryCharges/GrandTotal/MonetaryValue').to_s
                 total_price     = negotiated_rate.blank? ? rated_shipment.get_text('TotalCharges/MonetaryValue').to_s.to_f : negotiated_rate.to_f
                 currency        = negotiated_rate.blank? ? rated_shipment.get_text('TotalCharges/CurrencyCode').to_s : rated_shipment.get_text('NegotiatedRates/NetSummaryCharges/GrandTotal/CurrencyCode').to_s
-                
-                rate_estimates << ActiveMerchant::Shipping::RateEstimate.new(origin, destination, ActiveMerchant::Shipping::UPS.name,
+
+                rate_estimates << ::ActiveShipping::RateEstimate.new(origin, destination, ::ActiveShipping::UPS.name,
                                     service_name_for(origin, service_code),
                                     :total_price => total_price,
                                     :currency => currency,
@@ -263,7 +263,7 @@ module Spree
                                     )
               end
             end
-            ActiveMerchant::Shipping::RateResponse.new(success, message, Hash.from_xml(response).values.first, :rates => rate_estimates, :xml => response, :request => last_request)
+            ::ActiveShipping::RateResponse.new(success, message, Hash.from_xml(response).values.first, :rates => rate_estimates, :xml => response, :request => last_request)
           end
         end
       end

--- a/solidus_active_shipping.gemspec
+++ b/solidus_active_shipping.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('solidus', '~> 1.0.0')
-  s.add_dependency('active_shipping', '~> 0.12.6')
+  s.add_dependency('active_shipping', '~> 1.7.0')
   s.add_development_dependency 'pry'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'sass-rails', '~> 4.0.2'

--- a/spec/lib/spree/active_shipping/bogus_carrier.rb
+++ b/spec/lib/spree/active_shipping/bogus_carrier.rb
@@ -2,7 +2,7 @@ module Spree
   module ActiveShipping
     # Bogus carrier useful for testing.  For some reasons the plugin version of this class does not work
     # properly (it fails to return a RateResponse)
-    class BogusCarrier < ActiveMerchant::Shipping::Carrier
+    class BogusCarrier < ::ActiveShipping::Carrier
       def name
         "BogusCarrier"
       end

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-include ActiveMerchant::Shipping
+include ActiveShipping
 
 module ActiveShipping
   describe Spree::Calculator::Shipping do
@@ -29,7 +29,7 @@ module ActiveShipping
       order
     end
 
-    let(:carrier) { ActiveMerchant::Shipping::USPS.new(:login => "FAKEFAKEFAKE") }
+    let(:carrier) { ActiveShipping::USPS.new(:login => "FAKEFAKEFAKE") }
     let(:calculator) { Spree::Calculator::Shipping::Usps::ExpressMail.new }
     let(:response) { double('response', :rates => rates, :params => {}) }
     let(:package) { order.shipments.first.to_package }
@@ -86,7 +86,7 @@ module ActiveShipping
 
       context "when there is an error retrieving the rates" do
         before do
-          carrier.should_receive(:find_rates).and_raise(ActiveMerchant::ActiveMerchantError)
+          carrier.should_receive(:find_rates).and_raise(ActiveShipping::ResponseError)
         end
 
         it "should return false" do

--- a/spec/models/weight_limits_spec.rb
+++ b/spec/models/weight_limits_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-include ActiveMerchant::Shipping
+include ActiveShipping
 
 module ActiveShipping
   describe Spree::ShippingCalculator do


### PR DESCRIPTION
Current version is using an old, pre-release version of ActiveShipping (0.12.6).

I think it's a good time to update to the current version since we're basically starting with a clean slate and this extension is not used with Solidus, at least officially so we can probably afford to break compatibility a little.

Outside of getting bugfixes, new features and improvements, if we ever hope of adding new features to this extension or allow support for more complex use cases (printing shipping labels, manifests and so forth) we'll probably need to push some code upstream so it's easier to update now than later.

The interface is very much the same but there's a significant change with the namespace, post 1.0 use ActiveShipping instead of ActiveMerchant::Shipping so it messes with the extension since they are both using ActiveShipping.

Solution for now is to use "::" as a prefix since it allow access to class and instance methods from ActiveShipping outside of ActiveShipping so by using it we can make the distinction between ActiveShipping and Spree::ActiveShipping since we're calling the former from the latter but it's confusing nonetheless.

Suggestions are welcome.